### PR TITLE
fix pointer alignment to left as enforced

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -17,3 +17,5 @@ BraceWrapping:
   SplitEmptyNamespace: false
 BreakBeforeBraces: Custom
 ColumnLimit: 80
+DerivePointerAlignment: false
+PointerAlignment: Left

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 
 ## Enforced Style in clang-format
 
-[X] Max line length 80
-[X] curly bracket `{` for function will be on the newline
-[X] Pointer Alignment on the left
+- [x] Max line length 80
+- [x] curly bracket `{` for function will be on the newline
+- [x] Pointer Alignment on the left
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,17 @@
   * snake_case → function, namespace (no underscore),  variable, class member variable, member type
   * uppercase → macro
   * use typename in template (not class)
-  * private member → with _ suffex (e.g martabak_)
+  * private member → with _ suffix (e.g martabak_)
   * auto → ga dienforce
   * use trailing return type, except with void
   * const by default
 * Follow CppCoreGuidelines
+
+## Enforced Style in clang-format
+
+[X] Max line length 80
+[X] curly bracket `{` for function will be on the newline
+[X] Pointer Alignment on the left
 
 ## Requirements
 
@@ -21,3 +27,4 @@ List of Clang-Tidy checks can be found at https://releases.llvm.org/8.0.0/tools/
 
 ### Clang Format 8.0.0
 List of Clang-Format style options can be found at http://releases.llvm.org/8.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+


### PR DESCRIPTION
- enforced pointer alignment to the lest
- add check list for clang formatter on readme